### PR TITLE
Add Calendly link for Corporate plan

### DIFF
--- a/models/Profile.js
+++ b/models/Profile.js
@@ -77,6 +77,12 @@ const profileSchema = new mongoose.Schema({
     default: ''
   },
 
+  // Calendly integration for meeting scheduling
+  calendlyLink: {
+    type: String,
+    default: ''
+  },
+
   // Social handles
   socialLinks: {
     instagram: { type: String, default: '' },

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -77,14 +77,16 @@ router.put('/:id', async (req, res) => {
   try {
     const {
       name, title, subtitle, tags, bio,
-      location, phone, website, socialLinks, ownerEmail, industry
+      location, phone, website, socialLinks,
+      ownerEmail, industry, calendlyLink
     } = req.body;
 
     const profile = await Profile.findByIdAndUpdate(
       req.params.id,
       {
         name, title, subtitle, tags, bio,
-        location, phone, website, socialLinks, ownerEmail, industry
+        location, phone, website, socialLinks,
+        ownerEmail, industry, calendlyLink
       },
       { new: true }
     );

--- a/utils/fieldFilter.js
+++ b/utils/fieldFilter.js
@@ -1,7 +1,7 @@
 // utils/fieldFilter.js
 const PLAN_FIELDS = {
   Novice: ['name', 'title', 'subtitle', 'tags', 'phone', 'socialLinks'],
-  Corporate: ['name', 'title', 'subtitle', 'tags', 'phone', 'socialLinks', 'industry', 'website'],
+  Corporate: ['name', 'title', 'subtitle', 'tags', 'phone', 'socialLinks', 'industry', 'website', 'calendlyLink'],
   Elite: null  // null = no filtering
 };
 
@@ -30,7 +30,8 @@ function filterByPlan(profileObj) {
     const eliteRequired = [
       'name', 'title', 'subtitle', 'tags', 'phone', 'socialLinks',
       'industry', 'website', 'bannerUrl', 'avatarUrl', 'theme', 'email',
-      'location', 'customSlug', 'exclusiveBadge', 'createdAt'
+      'location', 'customSlug', 'exclusiveBadge', 'createdAt',
+      'calendlyLink'
     ];
     eliteRequired.forEach(f => {
       if (eliteProfile[f] === undefined) eliteProfile[f] = null;


### PR DESCRIPTION
## Summary
- add `calendlyLink` field to `Profile` schema
- allow profile update to set Calendly link
- expose Calendly link only for Corporate and Elite plans

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687f61dcf4548324a2bda600c6c61a44